### PR TITLE
Use symbolic path instead of path with route params filled in

### DIFF
--- a/lib/yabeda/grape.rb
+++ b/lib/yabeda/grape.rb
@@ -20,13 +20,13 @@ module Yabeda
           histogram :request_duration, unit: :seconds, buckets: LONG_RUNNING_REQUEST_BUCKETS,
                                        tags: %i[method path status],
                                        comment: "A histogram of the response latency."
-  
+
           ActiveSupport::Notifications.subscribe 'endpoint_run.grape' do |*args|
             event = ActiveSupport::Notifications::Event.new(*args)
 
             labels = {
               method: event.payload[:endpoint].options[:method].first.downcase,
-              path: event.payload[:endpoint].request.path,
+              path: event.payload[:endpoint].route.path,
               status: event.payload[:endpoint].status
             }
 

--- a/lib/yabeda/grape/version.rb
+++ b/lib/yabeda/grape/version.rb
@@ -1,5 +1,5 @@
 module Yabeda
   module Grape
-    VERSION = "0.1.3"
+    VERSION = "0.2.0"
   end
 end


### PR DESCRIPTION
## Scenario:

Suppose I have an endpoint with a route parameter, e.g. `GET /users/:id`.

Three HTTP calls are made:

```
GET /users/1
GET /users/2
GET /users/3
```

## Problem:
A new bucket is created for each user ID. This not only makes aggregation difficult, but it also (potentially) consumes a lot of memory when there are many users.

## Proposed Solution
Instead of aggregating based on the full path (e.g. `/users/1`), use the symbolic path (e.g. `/users/:id`)


## Before this PR
```
# TYPE grape_requests_total counter
# HELP grape_requests_total A counter of the total number of HTTP requests rails processed.
grape_requests_total{method="get",path="/api/v2/users/1.json",status="200"} 1.0
grape_requests_total{method="get",path="/api/v2/users/2.json",status="200"} 1.0
grape_requests_total{method="get",path="/api/v2/users/3.json",status="200"} 1.0
# TYPE grape_request_duration_seconds histogram
# HELP grape_request_duration_seconds A histogram of the response latency.
grape_request_duration_seconds_bucket{method="get",path="/api/v2/users/1.json",status="200",le="0.005"} 0.0
grape_request_duration_seconds_bucket{method="get",path="/api/v2/users/1.json",status="200",le="0.01"} 0.0
grape_request_duration_seconds_bucket{method="get",path="/api/v2/users/1.json",status="200",le="0.025"} 0.0
grape_request_duration_seconds_bucket{method="get",path="/api/v2/users/1.json",status="200",le="0.05"} 0.0
grape_request_duration_seconds_bucket{method="get",path="/api/v2/users/1.json",status="200",le="0.1"} 1.0
grape_request_duration_seconds_bucket{method="get",path="/api/v2/users/1.json",status="200",le="0.25"} 1.0
grape_request_duration_seconds_bucket{method="get",path="/api/v2/users/1.json",status="200",le="0.5"} 1.0
grape_request_duration_seconds_bucket{method="get",path="/api/v2/users/1.json",status="200",le="1"} 1.0
grape_request_duration_seconds_bucket{method="get",path="/api/v2/users/1.json",status="200",le="2.5"} 1.0
grape_request_duration_seconds_bucket{method="get",path="/api/v2/users/1.json",status="200",le="5"} 1.0
grape_request_duration_seconds_bucket{method="get",path="/api/v2/users/1.json",status="200",le="10"} 1.0
grape_request_duration_seconds_bucket{method="get",path="/api/v2/users/1.json",status="200",le="30"} 1.0
grape_request_duration_seconds_bucket{method="get",path="/api/v2/users/1.json",status="200",le="60"} 1.0
grape_request_duration_seconds_bucket{method="get",path="/api/v2/users/1.json",status="200",le="120"} 1.0
grape_request_duration_seconds_bucket{method="get",path="/api/v2/users/1.json",status="200",le="300"} 1.0
grape_request_duration_seconds_bucket{method="get",path="/api/v2/users/1.json",status="200",le="600"} 1.0
grape_request_duration_seconds_bucket{method="get",path="/api/v2/users/1.json",status="200",le="+Inf"} 1.0
grape_request_duration_seconds_sum{method="get",path="/api/v2/users/1.json",status="200"} 0.084
grape_request_duration_seconds_count{method="get",path="/api/v2/users/1.json",status="200"} 1.0
grape_request_duration_seconds_bucket{method="get",path="/api/v2/users/2.json",status="200",le="0.005"} 1.0
grape_request_duration_seconds_bucket{method="get",path="/api/v2/users/2.json",status="200",le="0.01"} 1.0
grape_request_duration_seconds_bucket{method="get",path="/api/v2/users/2.json",status="200",le="0.025"} 1.0
grape_request_duration_seconds_bucket{method="get",path="/api/v2/users/2.json",status="200",le="0.05"} 1.0
grape_request_duration_seconds_bucket{method="get",path="/api/v2/users/2.json",status="200",le="0.1"} 1.0
grape_request_duration_seconds_bucket{method="get",path="/api/v2/users/2.json",status="200",le="0.25"} 1.0
grape_request_duration_seconds_bucket{method="get",path="/api/v2/users/2.json",status="200",le="0.5"} 1.0
grape_request_duration_seconds_bucket{method="get",path="/api/v2/users/2.json",status="200",le="1"} 1.0
grape_request_duration_seconds_bucket{method="get",path="/api/v2/users/2.json",status="200",le="2.5"} 1.0
grape_request_duration_seconds_bucket{method="get",path="/api/v2/users/2.json",status="200",le="5"} 1.0
grape_request_duration_seconds_bucket{method="get",path="/api/v2/users/2.json",status="200",le="10"} 1.0
grape_request_duration_seconds_bucket{method="get",path="/api/v2/users/2.json",status="200",le="30"} 1.0
grape_request_duration_seconds_bucket{method="get",path="/api/v2/users/2.json",status="200",le="60"} 1.0
grape_request_duration_seconds_bucket{method="get",path="/api/v2/users/2.json",status="200",le="120"} 1.0
grape_request_duration_seconds_bucket{method="get",path="/api/v2/users/2.json",status="200",le="300"} 1.0
grape_request_duration_seconds_bucket{method="get",path="/api/v2/users/2.json",status="200",le="600"} 1.0
grape_request_duration_seconds_bucket{method="get",path="/api/v2/users/2.json",status="200",le="+Inf"} 1.0
grape_request_duration_seconds_sum{method="get",path="/api/v2/users/2.json",status="200"} 0.003
grape_request_duration_seconds_count{method="get",path="/api/v2/users/2.json",status="200"} 1.0
grape_request_duration_seconds_bucket{method="get",path="/api/v2/users/3.json",status="200",le="0.005"} 1.0
grape_request_duration_seconds_bucket{method="get",path="/api/v2/users/3.json",status="200",le="0.01"} 1.0
grape_request_duration_seconds_bucket{method="get",path="/api/v2/users/3.json",status="200",le="0.025"} 1.0
grape_request_duration_seconds_bucket{method="get",path="/api/v2/users/3.json",status="200",le="0.05"} 1.0
grape_request_duration_seconds_bucket{method="get",path="/api/v2/users/3.json",status="200",le="0.1"} 1.0
grape_request_duration_seconds_bucket{method="get",path="/api/v2/users/3.json",status="200",le="0.25"} 1.0
grape_request_duration_seconds_bucket{method="get",path="/api/v2/users/3.json",status="200",le="0.5"} 1.0
grape_request_duration_seconds_bucket{method="get",path="/api/v2/users/3.json",status="200",le="1"} 1.0
grape_request_duration_seconds_bucket{method="get",path="/api/v2/users/3.json",status="200",le="2.5"} 1.0
grape_request_duration_seconds_bucket{method="get",path="/api/v2/users/3.json",status="200",le="5"} 1.0
grape_request_duration_seconds_bucket{method="get",path="/api/v2/users/3.json",status="200",le="10"} 1.0
grape_request_duration_seconds_bucket{method="get",path="/api/v2/users/3.json",status="200",le="30"} 1.0
grape_request_duration_seconds_bucket{method="get",path="/api/v2/users/3.json",status="200",le="60"} 1.0
grape_request_duration_seconds_bucket{method="get",path="/api/v2/users/3.json",status="200",le="120"} 1.0
grape_request_duration_seconds_bucket{method="get",path="/api/v2/users/3.json",status="200",le="300"} 1.0
grape_request_duration_seconds_bucket{method="get",path="/api/v2/users/3.json",status="200",le="600"} 1.0
grape_request_duration_seconds_bucket{method="get",path="/api/v2/users/3.json",status="200",le="+Inf"} 1.0
grape_request_duration_seconds_sum{method="get",path="/api/v2/users/3.json",status="200"} 0.003
grape_request_duration_seconds_count{method="get",path="/api/v2/users/3.json",status="200"} 1.0
```

## After this PR

```
# TYPE grape_requests_total counter
# HELP grape_requests_total A counter of the total number of HTTP requests rails processed.
grape_requests_total{method="get",path="/users/:id(.json)",status="200"} 3.0
# TYPE grape_request_duration_seconds histogram
# HELP grape_request_duration_seconds A histogram of the response latency.
grape_request_duration_seconds_bucket{method="get",path="/users/:id(.json)",status="200",le="0.005"} 2.0
grape_request_duration_seconds_bucket{method="get",path="/users/:id(.json)",status="200",le="0.01"} 2.0
grape_request_duration_seconds_bucket{method="get",path="/users/:id(.json)",status="200",le="0.025"} 2.0
grape_request_duration_seconds_bucket{method="get",path="/users/:id(.json)",status="200",le="0.05"} 2.0
grape_request_duration_seconds_bucket{method="get",path="/users/:id(.json)",status="200",le="0.1"} 3.0
grape_request_duration_seconds_bucket{method="get",path="/users/:id(.json)",status="200",le="0.25"} 3.0
grape_request_duration_seconds_bucket{method="get",path="/users/:id(.json)",status="200",le="0.5"} 3.0
grape_request_duration_seconds_bucket{method="get",path="/users/:id(.json)",status="200",le="1"} 3.0
grape_request_duration_seconds_bucket{method="get",path="/users/:id(.json)",status="200",le="2.5"} 3.0
grape_request_duration_seconds_bucket{method="get",path="/users/:id(.json)",status="200",le="5"} 3.0
grape_request_duration_seconds_bucket{method="get",path="/users/:id(.json)",status="200",le="10"} 3.0
grape_request_duration_seconds_bucket{method="get",path="/users/:id(.json)",status="200",le="30"} 3.0
grape_request_duration_seconds_bucket{method="get",path="/users/:id(.json)",status="200",le="60"} 3.0
grape_request_duration_seconds_bucket{method="get",path="/users/:id(.json)",status="200",le="120"} 3.0
grape_request_duration_seconds_bucket{method="get",path="/users/:id(.json)",status="200",le="300"} 3.0
grape_request_duration_seconds_bucket{method="get",path="/users/:id(.json)",status="200",le="600"} 3.0
grape_request_duration_seconds_bucket{method="get",path="/users/:id(.json)",status="200",le="+Inf"} 3.0
grape_request_duration_seconds_sum{method="get",path="/users/:id(.json)",status="200"} 0.065
grape_request_duration_seconds_count{method="get",path="/users/:id(.json)",status="200"} 3.0
```